### PR TITLE
Ignore Jupyter notebook checkpoints everywhere in repository.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.ipynb_checkpoints


### PR DESCRIPTION
Hi @ana42742!

I noticed there was an [.ipynb_checkpoints](https://github.com/mkcor/draft-notebooks/tree/main/embryo/.ipynb_checkpoints) directory in the `embryo` subdirectory: Typically, we don't want to track notebook checkpoints.

Reference: https://stackoverflow.com/questions/35916658/how-to-git-ignore-ipython-notebook-checkpoints-anywhere-in-repository